### PR TITLE
Modify Routes.go to help gemini understand better

### DIFF
--- a/handlers/routes.go
+++ b/handlers/routes.go
@@ -106,12 +106,6 @@ func getRoutesEnhanced(client *alkira.AlkiraClient, params EnhancedRouteQueryPar
 
 func GetRoutes(client *alkira.AlkiraClient) func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		// Validate required parameters
-		_, err := request.RequireString("tenantNetworkId")
-		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
-		}
-
 		routeType := request.GetString("type", "received")
 		if routeType != "received" && routeType != "advertised" && routeType != "overlap" {
 			return mcp.NewToolResultError("type must be 'received', 'advertised', or 'overlap'"), nil
@@ -180,12 +174,6 @@ func GetRoutes(client *alkira.AlkiraClient) func(ctx context.Context, request mc
 
 func GetRouteCount(client *alkira.AlkiraClient) func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		// Validate required parameters
-		_, err := request.RequireString("tenantNetworkId")
-		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
-		}
-
 		routeType := request.GetString("type", "received")
 		if routeType != "received" && routeType != "advertised" && routeType != "overlap" {
 			return mcp.NewToolResultError("type must be 'received', 'advertised', or 'overlap'"), nil
@@ -565,12 +553,6 @@ func contains(slice []string, item string) bool {
 // GetRouteSummary handler
 func GetRouteSummary(client *alkira.AlkiraClient) func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		// Extract tenant network ID (required)
-		_, err := request.RequireString("tenantNetworkId")
-		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
-		}
-
 		// Extract parameters
 		routeType := request.GetString("type", "received")
 		groupBy := request.GetString("groupBy", "connectorType")
@@ -598,12 +580,6 @@ func GetRouteSummary(client *alkira.AlkiraClient) func(ctx context.Context, requ
 // GetAllRoutes handler with automatic pagination
 func GetAllRoutes(client *alkira.AlkiraClient) func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		// Extract tenant network ID (required)
-		_, err := request.RequireString("tenantNetworkId")
-		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
-		}
-
 		// Extract parameters
 		routeType := request.GetString("type", "received")
 		batchSize := request.GetInt("batchSize", 50)

--- a/tools/routes.go
+++ b/tools/routes.go
@@ -7,7 +7,6 @@ import (
 func GetRoutes() mcp.Tool {
 	return mcp.NewTool("getRoutes",
 		mcp.WithDescription("Retrieve detailed route information from the routes cache. Examples: Get received routes for segment 'Seg1', Find routes for connector ID 60, Search routes containing 'customer'. Returns route objects with connector details, BGP attributes, segment assignments, and inter-CXP relationships. Requires pagination for large datasets (use limit=100). For advertised routes, specify segmentName or cxp. Common combinations: type+segmentName, type+connectorId+segmentName, type+cxp."),
-		mcp.WithString("tenantNetworkId", mcp.Required(), mcp.Description("Tenant network ID to query routes for")),
 		mcp.WithString("type", mcp.Required(), mcp.Description("Routes type cache to pull: 'received' (routes learned by Alkira) or 'advertised' (routes Alkira advertises to connectors)")),
 		mcp.WithString("segmentName", mcp.Description("Filter by network segment - isolated routing domains that provide security boundaries and traffic control (e.g., 'Corporate', 'DMZ')")),
 		mcp.WithString("segmentNames", mcp.Description("Comma-separated list of segment names to match against (e.g., 'seg1,seg2')")),
@@ -40,7 +39,6 @@ func GetRoutes() mcp.Tool {
 func GetRouteCount() mcp.Tool {
 	return mcp.NewTool("getRouteCount",
 		mcp.WithDescription("Get route count matching specified criteria. More efficient than getRoutes for count-only queries. Useful for: checking route table sizes before pagination, monitoring route growth, validating filter effectiveness before full data retrieval."),
-		mcp.WithString("tenantNetworkId", mcp.Required(), mcp.Description("Tenant network ID to count routes for")),
 		mcp.WithString("type", mcp.Required(), mcp.Description("Routes type cache to count: 'received' (routes learned by Alkira) or 'advertised' (routes Alkira advertises to connectors)")),
 		mcp.WithString("segmentName", mcp.Description("Filter by network segment - isolated routing domains that provide security boundaries and traffic control (e.g., 'Corporate', 'DMZ')")),
 		mcp.WithString("segmentNames", mcp.Description("Comma-separated list of segment names to match against (e.g., 'seg1,seg2')")),
@@ -71,7 +69,6 @@ func GetRouteCount() mcp.Tool {
 func GetRouteSummary() mcp.Tool {
 	return mcp.NewTool("getRouteSummary",
 		mcp.WithDescription("Get aggregated route analytics grouped by connector type, segment, or CXP. Provides route distribution insights, connector utilization, and network topology understanding. Use includeDetails for per-connector breakdowns."),
-		mcp.WithString("tenantNetworkId", mcp.Required(), mcp.Description("The tenant network ID")),
 		mcp.WithString("type", mcp.Required(), mcp.Description("Route type: 'received', 'advertised', or 'overlap' (required)")),
 		mcp.WithString("groupBy", mcp.Description("Group routes by: connectorType, segment, cxp, connectorName, prefixRange (default: connectorType)")),
 		mcp.WithBoolean("includeDetails", mcp.Description("Include detailed breakdown (default: false)")),
@@ -83,7 +80,6 @@ func GetRouteSummary() mcp.Tool {
 func GetAllRoutes() mcp.Tool {
 	return mcp.NewTool("getAllRoutes",
 		mcp.WithDescription("Get ALL routes with automatic pagination (handles large result sets efficiently)"),
-		mcp.WithString("tenantNetworkId", mcp.Required(), mcp.Description("The tenant network ID")),
 		mcp.WithString("type", mcp.Required(), mcp.Description("Route type: 'received', 'advertised', or 'overlap' (required)")),
 		mcp.WithNumber("batchSize", mcp.Description("Routes per batch (default: 50, max: 100)")),
 		mcp.WithString("outputFormat", mcp.Description("Output format: json, summary, count (default: json)")),


### PR DESCRIPTION
Gemini cli was extremely confused by the `_, err := request.RequireString("tenantNetworkId")` lines and kept insisting I tell it what the tenantNetworkId was (even though that info is already in the Alkira client it creates...).  

These changes fixed the issue, and it was able to get routes from my tenant afterwards :) 

Not clear if this is Gemini cli being dumb or not though, because as per Josh Claude has no issues :|.  Draft PR for now, going to do some looking into how request.RequireString and mcp.WithString are supposed to work to get a better idea of whats going on lol.  