### PR TITLE
docs: Add comprehensive tool reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,135 @@ AVAILABLE TOOLS
 
 In AI fashion, just ask the agent what's all available tools from
 mcp-alkira.
+
+### Tool Categories
+
+The MCP server provides **~120 tools** organized into the following categories:
+
+#### Tenant & Network
+| Tool | Description |
+|------|-------------|
+| `TenantNetworkSummary` | Get tenant network overview |
+| `TenantResourceUsages` | Current resource usage |
+| `TenantResourceLimits` | Resource limits |
+
+#### Billing & CXPs
+| Tool | Description |
+|------|-------------|
+| `BillingTagGetAll` | List all billing tags |
+| `BillingTagGetById` | Get billing tag by ID |
+| `BillingTagGetByName` | Get billing tag by name |
+| `BillingTagGetTotal` | Get total billing tag count |
+| `CxpGetAll` | List all CXPs |
+
+#### Segments & Groups
+| Tool | Description |
+|------|-------------|
+| `SegmentGetAll` | List all segments |
+| `SegmentGetById` | Get segment by ID |
+| `SegmentGetByName` | Get segment by name |
+| `GroupGetById` | Get group by ID |
+| `GroupGetByName` | Get group by name |
+| `GroupGetTotal` | Get total group count |
+| `SegmentResourceGetAll/ById/ByName/Total` | Segment resource operations |
+| `SegmentResourceShareGetAll/ById/ByName/Total` | Resource share operations |
+
+#### Connectors
+
+Each connector type supports: `GetAll`, `GetById`, `GetByName`, `GetTotal`
+
+| Category | Connector Types |
+|----------|-----------------|
+| **Cloud** | AWS VPC, Azure VNet, GCP VPC, OCI VCN |
+| **WAN** | AWS Direct Connect, Azure ExpressRoute, GCP Interconnect |
+| **SD-WAN** | Cisco, Fortinet, Aruba Edge, Versa, VMware (VeloCloud) |
+| **Branch** | IPSec, IPSec Advanced, Remote Access |
+| **Transit** | AWS TGW |
+| **Other** | Internet |
+
+#### Services
+
+Each service type supports: `GetAll`, `GetById`, `GetByName`, `GetTotal`
+
+| Service | Description |
+|---------|-------------|
+| PAN | Palo Alto Networks firewall |
+| Fortinet | FortiGate firewall |
+| Check Point | Check Point firewall |
+| Cisco FTDv | Cisco Firepower Threat Defense |
+| Zscaler | Zscaler Internet Access |
+| F5 LB | F5 Load Balancer |
+| Infoblox | DNS/DHCP/IPAM |
+
+#### Routes
+| Tool | Description |
+|------|-------------|
+| `GetRoutes` | Query routes with filters |
+| `GetRouteCount` | Count routes matching criteria |
+| `GetRouteSummary` | Route summary by segment |
+| `GetAllRoutes` | Get all routes (use with caution) |
+
+#### Policies
+
+**NAT Policies:**
+- `PolicyNatGetAll/ById/ByName/Total` - NAT policy operations
+- `PolicyNatRuleGetAll/ById/ByName/Total` - NAT rule operations
+
+**Route Policies:**
+- `PolicyRouteGetAll/ById/ByName/Total` - Route policy operations
+
+**Traffic Policies:**
+- `PolicyTrafficGetAll/ById/ByName` - Traffic policy operations
+- `PolicyTrafficRuleGetAll/ById/ByName` - Traffic rule operations
+- `PolicyTrafficRuleListGetAll/ById/ByName` - Traffic rule list operations
+
+#### Lists
+| List Type | Tools |
+|-----------|-------|
+| AS Path | `ListAsPathGetAll/ById/ByName/Total` |
+| BGP Community | `ListCommunityGetAll/ById/ByName/Total` |
+| Extended Community | `ListExtendedCommunityGetAll/ById/ByName/Total` |
+| DNS Server | `ListDnsServerGetAll/ById/ByName/Total` |
+| Global CIDR | `ListGlobalCidrGetAll/ById/ByName/Total` |
+| UDR | `ListUdrGetAll/ById/ByName/Total` |
+| Prefix | `ListPrefixGetById/ByName/ByPrefix` |
+| Policy FQDN | `ListPolicyFqdnGetAll/ById/ByName/Total` |
+
+#### Internet Applications
+| Tool | Description |
+|------|-------------|
+| `InternetApplicationGetAll` | List all internet applications |
+| `InternetApplicationGetById` | Get by ID |
+| `InternetApplicationGetByName` | Get by name |
+| `InternetApplicationGetTotal` | Get total count |
+
+#### Health & Monitoring
+| Tool | Description |
+|------|-------------|
+| `HealthConnectorGetById` | Get connector health status |
+| `HealthConnectorInstanceGetById` | Get connector instance health |
+| `HealthServiceGetById` | Get service health status |
+| `HealthServiceInstanceGetById` | Get service instance health |
+| `Alerts` | Get alerts |
+| `AuditLogs` | Get audit logs |
+| `Jobs` | Get jobs |
+
+
+COMMAND LINE OPTIONS
+---
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--portal` | (required) | Alkira Portal URL |
+| `--key` | (required) | API key |
+| `--mode` | `stdio` | Server mode: `stdio` or `sse` |
+| `--port` | `8081` | Port for SSE mode |
+| `--maxToken` | `0` | Max token payload size |
+
+
+PROMPTS
+---
+
+| Prompt | Description |
+|--------|-------------|
+| `summary` | Generate a quick tenant summary |


### PR DESCRIPTION
## Summary
- Add detailed documentation of all ~120 available MCP tools organized by category
- Add command line options reference table
- Add prompts section

## Tool Categories Documented
- Tenant & Network tools
- Billing & CXP tools  
- Segments & Groups tools
- Connector tools (Cloud, WAN, SD-WAN, Branch, Transit)
- Service tools (PAN, Fortinet, Check Point, Zscaler, F5, Infoblox)
- Route tools
- Policy tools (NAT, Route, Traffic)
- List tools (AS Path, Community, CIDR, Prefix, FQDN, etc.)
- Internet Application tools
- Health & Monitoring tools

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify tool names match actual implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)